### PR TITLE
fix: address second order command injection

### DIFF
--- a/src/commitSha.ts
+++ b/src/commitSha.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github'
 
 import {Env} from './env'
 import {Inputs} from './inputs'
+import { isSafeGitArg } from './utils'
 import {
   canDiffCommits,
   cleanShaInput,
@@ -343,6 +344,31 @@ export const getSHAForPullRequestEvent = async ({
 }: SHAForPullRequestEvent): Promise<DiffResult> => {
   let targetBranch = github.context.payload.pull_request?.base?.ref
   const currentBranch = github.context.payload.pull_request?.head?.ref
+
+  // Validate branch/ref names and any gitFetchExtraArgs that may be tainted
+  import { isSafeGitArg } from './utils'
+  const argListToValidate = [
+    ...(Array.isArray(gitFetchExtraArgs) ? gitFetchExtraArgs : []),
+    remoteName
+  ]
+  if (currentBranch && !isSafeGitArg(currentBranch)) {
+    throw new Error(
+      `Unsafe branch name detected in PR head.ref: "${currentBranch}". Possible injection attempt.`
+    )
+  }
+  if (targetBranch && !isSafeGitArg(targetBranch)) {
+    throw new Error(
+      `Unsafe branch name detected in PR base.ref: "${targetBranch}". Possible injection attempt.`
+    )
+  }
+  for (const a of argListToValidate) {
+    if (!isSafeGitArg(a)) {
+      throw new Error(
+        `Unsafe extra git argument detected: "${a}". Possible injection attempt.`
+      )
+    }
+  }
+
   if (inputs.sinceLastRemoteCommit) {
     targetBranch = currentBranch
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -285,6 +285,28 @@ export const submoduleExists = async ({
 }
 
 /**
+ * Checks if a string is safe to use as a git argument (prevents option injection)
+ * @param val - the argument to check
+ * @returns true if safe, false otherwise
+ */
+export function isSafeGitArg(val: string): boolean {
+  // Disallow args that start with dash, are empty, or obviously suspicious
+  if (!val || typeof val !== 'string') return false
+  if (val.startsWith('-')) return false
+  // Disallow sequences forbidden in git refs: spaces, control chars, "..", ".lock", etc.
+  if (/[ \t\n\r]/.test(val)) return false
+  if (val.includes('..')) return false
+  if (val.endsWith('.lock')) return false
+  if (val.includes('@{')) return false
+  if (val.includes('\\')) return false
+  if (val.startsWith('/')) return false
+  if (val.endsWith('/')) return false
+  if (val.includes('//')) return false
+  if (val.match(/[\x00-\x1F\x7F]/)) return false
+  return true
+}
+
+/**
  * Fetches the git repository
  * @param args - arguments for fetch command
  * @param cwd - working directory


### PR DESCRIPTION
Potential fix for [https://github.com/Lendable/changed-files/security/code-scanning/1](https://github.com/Lendable/changed-files/security/code-scanning/1)

**How to generally fix the problem:**  
To fix this vulnerability, all user-controlled arguments that are used as git ref names or branch names should be validated or sanitized before being passed into any git command. Specifically, you should ensure that neither `head.ref` nor any other PR-controlled argument can start with `-` (which would treat the argument as a git option), and ideally check that it matches the allowed format for git ref names.

**Single best way to fix:**  
Implement a function (e.g., `isValidGitRef`) that validates candidate branch names before using them as git arguments. The function should ensure:
- The value is non-empty.
- It does NOT start with `-`.  
- It matches the allowed git refname pattern (e.g., not containing `..`, not ending with `.lock`, etc.) for increased robustness, but at minimum, prevent leading dashes.

**Specific regions to change:**  
- In `src/commitSha.ts`: Before using any value from `github.context.payload.pull_request?.head?.ref` or `...gitFetchExtraArgs`, ensure that each ref or extra arg is validated for safety.
- The most robust place to handle this is right before we call `gitFetch` or `gitFetchSubmodules` in `getSHAForPullRequestEvent`. Add a validation for the relevant variables (`currentBranch`, items in `gitFetchExtraArgs`), and throw an error if the check fails.

**What is needed:**  
- Implement a function `isSafeGitArg(val: string): boolean` in `src/utils.ts`, just above the `gitFetch` function.
- In `src/commitSha.ts`, before passing `currentBranch` or anything from `gitFetchExtraArgs` to git, assert all are safe using `isSafeGitArg`. If an unsafe value is found, throw with a clear message.
- Import the function (if not in same module or file).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
